### PR TITLE
Setup source files' path as constant

### DIFF
--- a/Installer/OnlyMSetup.iss
+++ b/Installer/OnlyMSetup.iss
@@ -5,8 +5,9 @@
 #define MyAppPublisher "Antony Corbett"
 #define MyAppURL "https://soundboxsoftware.com"
 #define MyAppExeName "OnlyM.exe"
+#define MySource "d:\ProjectsPersonal\OnlyM\OnlyM"
 
-#define MyAppVersion GetFileVersion('d:\ProjectsPersonal\OnlyM\OnlyM\bin\Release\OnlyM.exe');
+#define MyAppVersion GetFileVersion(MySource + '\bin\Release\OnlyM.exe');
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application.
@@ -22,7 +23,8 @@ AppUpdatesURL={#MyAppURL}
 DefaultDirName={pf}\OnlyM
 DefaultGroupName={#MyAppName}
 OutputBaseFilename=OnlyMSetup
-SetupIconFile=d:\ProjectsPersonal\OnlyM\OnlyM\icon.ico
+SetupIconFile=icon.ico
+SourceDir={#MySource}
 Compression=lzma
 SolidCompression=yes
 AppContact=antony@corbetts.org.uk
@@ -36,36 +38,36 @@ AppMutex=OnlyMMeetingMedia
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"
 
 [Files]
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\FFmpeg\*"; DestDir: "{app}\FFmpeg"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\x64\*"; DestDir: "{app}\x64"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\x86\*"; DestDir: "{app}\x86"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\AutoMapper.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\CommonServiceLocator.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\ffme.common.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\ffme.win.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\FFmpeg.AutoGen.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\FluentCommandLineParser.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\GalaSoft.MvvmLight.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\GalaSoft.MvvmLight.Extras.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\GalaSoft.MvvmLight.Platform.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\MaterialDesignColors.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\MaterialDesignThemes.Wpf.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\Microsoft.WindowsAPICodePack.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\Microsoft.WindowsAPICodePack.Shell.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\Microsoft.WindowsAPICodePack.ShellExtensions.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\Newtonsoft.Json.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\OnlyM.Core.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\OnlyM.exe"; DestDir: "{app}"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\OnlyM.exe.config"; DestDir: "{app}"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\policy.2.0.taglib-sharp.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\Serilog.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\Serilog.Sinks.Console.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\Serilog.Sinks.File.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\Serilog.Sinks.RollingFile.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\System.Data.SQLite.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\System.ValueTuple.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\System.Windows.Interactivity.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "\ProjectsPersonal\OnlyM\OnlyM\bin\Release\taglib-sharp.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\Release\FFmpeg\*"; DestDir: "{app}\FFmpeg"; Flags: ignoreversion
+Source: "bin\Release\x64\*"; DestDir: "{app}\x64"; Flags: ignoreversion
+Source: "bin\Release\x86\*"; DestDir: "{app}\x86"; Flags: ignoreversion
+Source: "bin\Release\AutoMapper.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\Release\CommonServiceLocator.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\Release\ffme.common.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\Release\ffme.win.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\Release\FFmpeg.AutoGen.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\Release\FluentCommandLineParser.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\Release\GalaSoft.MvvmLight.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\Release\GalaSoft.MvvmLight.Extras.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\Release\GalaSoft.MvvmLight.Platform.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\Release\MaterialDesignColors.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\Release\MaterialDesignThemes.Wpf.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\Release\Microsoft.WindowsAPICodePack.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\Release\Microsoft.WindowsAPICodePack.Shell.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\Release\Microsoft.WindowsAPICodePack.ShellExtensions.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\Release\Newtonsoft.Json.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\Release\OnlyM.Core.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\Release\OnlyM.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\Release\OnlyM.exe.config"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\Release\policy.2.0.taglib-sharp.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\Release\Serilog.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\Release\Serilog.Sinks.Console.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\Release\Serilog.Sinks.File.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\Release\Serilog.Sinks.RollingFile.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\Release\System.Data.SQLite.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\Release\System.ValueTuple.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\Release\System.Windows.Interactivity.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "bin\Release\taglib-sharp.dll"; DestDir: "{app}"; Flags: ignoreversion
 
 [Icons]
 Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"


### PR DESCRIPTION
I added a SourceDir directive in the [Setup] section of OnlyMSetup.iss, set it with the constant "MySource" and then made some cleanup. This way it's not necessary to edit the whole script in case someone tries to recompile the installer after dowloading the project and making some work/experiment. Or you simply moved your files for some reason.

(View this pull request as a suggestion. No hard feelings in case of rejection, of course. 😉)