### PR TITLE
Check image file's last modification before return cached image (Fix #380)

### DIFF
--- a/OnlyM/Services/ImagesCache/ImageAndLastUsed.cs
+++ b/OnlyM/Services/ImagesCache/ImageAndLastUsed.cs
@@ -7,6 +7,8 @@
     {
         public BitmapSource BitmapImage { get; set; }
 
+        public DateTime LastChangedUtc { get; set; }
+
         public DateTime LastUsedUtc { get; set; }
     }
 }

--- a/OnlyM/Services/ImagesCache/ImageCache.cs
+++ b/OnlyM/Services/ImagesCache/ImageCache.cs
@@ -26,7 +26,7 @@
                 return null;
             }
 
-            DateTime fileLastChangedUtc = File.GetLastWriteTimeUtc(filePath);
+            DateTime fileLastChangedUtc = File.GetLastWriteTimeUtc(fullPath);
             if (_cache.TryGetValue(fullPath, out var result))
             {
                 if (result.LastChangedUtc == fileLastChangedUtc)

--- a/OnlyM/Services/ImagesCache/ImageCache.cs
+++ b/OnlyM/Services/ImagesCache/ImageCache.cs
@@ -33,7 +33,7 @@
                 {
                     Log.Logger.Debug($"Image in cache: {fullPath}");
                     result.LastUsedUtc = DateTime.UtcNow;
-                    return result;
+                    return result.BitmapImage;
                 }
 
                 // Cached item is invalid. Delete and recreate


### PR DESCRIPTION
Thanks for sending a pull request! Please review the [guidelines for contributing](CONTRIBUTING.md), then fill out the blanks below.

What does this implement/fix? Explain your changes
--------------------------------------------------
In ImageCache.cs, check that image file still exists and that the file's last modification time is still the same before returning cache entry.

Does this close any currently open issues?
------------------------------------------
#380 Wrong image displayed after replacing file (ImageCache issue)