### PR TITLE
New: Resize window on new media

### DIFF
--- a/OnlyM.Core/Services/Options/IOptionsService.cs
+++ b/OnlyM.Core/Services/Options/IOptionsService.cs
@@ -108,6 +108,8 @@
         bool MediaWindowed { get; set; }
 
         bool WindowedAlwaysOnTop { get; set; }
+        
+        bool AutoResizeMediaWindow { get; set; }
 
         double BrowserZoomLevelIncrement { get; set; }
         

--- a/OnlyM.Core/Services/Options/Options.cs
+++ b/OnlyM.Core/Services/Options/Options.cs
@@ -100,6 +100,8 @@
         public bool AlwaysOnTop { get; set; }
 
         public bool WindowedAlwaysOnTop { get; set; }
+        
+        public bool AutoResizeMediaWindow { get; set; }
 
         public string AppWindowPlacement { get; set; }
 

--- a/OnlyM.Core/Services/Options/OptionsService.cs
+++ b/OnlyM.Core/Services/Options/OptionsService.cs
@@ -52,6 +52,8 @@
 
         public event EventHandler WindowedMediaAlwaysOnTopChangedEvent;
 
+        public event EventHandler AutoResizeMediaWindowChangedEvent;
+
         public event EventHandler<MonitorChangedEventArgs> MediaMonitorChangedEvent;
 
         public event EventHandler RenderingMethodChangedEvent;
@@ -466,6 +468,19 @@
                 {
                     _options.Value.WindowedAlwaysOnTop = value;
                     WindowedMediaAlwaysOnTopChangedEvent?.Invoke(this, EventArgs.Empty);
+                }
+            }
+        }
+
+        public bool AutoResizeMediaWindow
+        {
+            get => _options.Value.AutoResizeMediaWindow;
+            set
+            {
+                if (_options.Value.AutoResizeMediaWindow != value)
+                {
+                    _options.Value.AutoResizeMediaWindow = value;
+                    AutoResizeMediaWindowChangedEvent?.Invoke(this, EventArgs.Empty);
                 }
             }
         }

--- a/OnlyM/MediaElementAdaption/IMediaElement.cs
+++ b/OnlyM/MediaElementAdaption/IMediaElement.cs
@@ -25,6 +25,10 @@
 
         Duration NaturalDuration { get; }
 
+        int NaturalVideoWidth { get; }
+
+        int NaturalVideoHeight { get; }
+
         bool IsPaused { get; }
 
         Guid MediaItemId { get; set; }

--- a/OnlyM/MediaElementAdaption/MediaElementMediaFoundation.cs
+++ b/OnlyM/MediaElementAdaption/MediaElementMediaFoundation.cs
@@ -110,7 +110,11 @@
 
                 return _mediaElement.NaturalDuration;
             }
-        } 
+        }
+
+        public int NaturalVideoWidth => _mediaElement.NaturalVideoWidth;
+
+        public int NaturalVideoHeight => _mediaElement.NaturalVideoHeight;
 
         public Task Play(Uri mediaPath, MediaClassification mediaClassification)
         {

--- a/OnlyM/MediaElementAdaption/MediaElementUnoSquare.cs
+++ b/OnlyM/MediaElementAdaption/MediaElementUnoSquare.cs
@@ -48,6 +48,10 @@
 
         public Duration NaturalDuration => _mediaElement.NaturalDuration;
 
+        public int NaturalVideoWidth => _mediaElement.NaturalVideoWidth;
+
+        public int NaturalVideoHeight => _mediaElement.NaturalVideoHeight;
+
         public FrameworkElement FrameworkElement => _mediaElement;
 
         public Guid MediaItemId { get; set; }

--- a/OnlyM/Models/NewMediaSizeEventArgs.cs
+++ b/OnlyM/Models/NewMediaSizeEventArgs.cs
@@ -1,15 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace OnlyM.Models
+﻿namespace OnlyM.Models
 {
+    using System;
+
     public class NewMediaSizeEventArgs : EventArgs
     {
         public int Width { get; set; }
-        public int Height { get; set; }
 
+        public int Height { get; set; }
     }
 }

--- a/OnlyM/Models/NewMediaSizeEventArgs.cs
+++ b/OnlyM/Models/NewMediaSizeEventArgs.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OnlyM.Models
+{
+    public class NewMediaSizeEventArgs : EventArgs
+    {
+        public int Width { get; set; }
+        public int Height { get; set; }
+
+    }
+}

--- a/OnlyM/OnlyM.csproj
+++ b/OnlyM/OnlyM.csproj
@@ -211,6 +211,7 @@
     <Compile Include="Models\MediaEventArgs.cs" />
     <Compile Include="Models\MediaNearEndEventArgs.cs" />
     <Compile Include="Models\MonitorItem.cs" />
+    <Compile Include="Models\NewMediaSizeEventArgs.cs" />
     <Compile Include="Models\PdfOptions.cs" />
     <Compile Include="Models\PdfViewStyle.cs" />
     <Compile Include="Models\PdfViewStyleAndDescription.cs" />

--- a/OnlyM/Properties/Resources.Designer.cs
+++ b/OnlyM/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace OnlyM.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -120,6 +120,15 @@ namespace OnlyM.Properties {
         public static string APP_VER {
             get {
                 return ResourceManager.GetString("APP_VER", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Auto-resize media window.
+        /// </summary>
+        public static string AUTO_RESIZE_MEDIA_WINDOW {
+            get {
+                return ResourceManager.GetString("AUTO_RESIZE_MEDIA_WINDOW", resourceCulture);
             }
         }
         

--- a/OnlyM/Properties/Resources.de-DE.resx
+++ b/OnlyM/Properties/Resources.de-DE.resx
@@ -572,4 +572,8 @@
     <value>Immer im Vordergrund (Fenstermodus)</value>
     <comment>Option in Settings =&gt; Display</comment>
   </data>
+  <data name="AUTO_RESIZE_MEDIA_WINDOW" xml:space="preserve">
+    <value>Fenster automatisch anpassen</value>
+    <comment>Option in Settings =&gt; Display</comment>
+  </data>
 </root>

--- a/OnlyM/Properties/Resources.en-US.resx
+++ b/OnlyM/Properties/Resources.en-US.resx
@@ -572,4 +572,8 @@
     <value>Always on top (windowed)</value>
     <comment>Option in Settings =&gt; Display</comment>
   </data>
+  <data name="AUTO_RESIZE_MEDIA_WINDOW" xml:space="preserve">
+    <value>Auto-resize media window</value>
+    <comment>Option in Settings =&gt; Display</comment>
+  </data>
 </root>

--- a/OnlyM/Properties/Resources.resx
+++ b/OnlyM/Properties/Resources.resx
@@ -572,4 +572,8 @@
     <value>Always on top (windowed)</value>
     <comment>Option in Settings =&gt; Display</comment>
   </data>
+  <data name="AUTO_RESIZE_MEDIA_WINDOW" xml:space="preserve">
+    <value>Auto-resize media window</value>
+    <comment>Option in Settings =&gt; Display</comment>
+  </data>
 </root>

--- a/OnlyM/Services/ImageDisplayManager.cs
+++ b/OnlyM/Services/ImageDisplayManager.cs
@@ -9,6 +9,7 @@
     using System.Windows.Controls;
     using System.Windows.Media;
     using System.Windows.Media.Animation;
+    using System.Windows.Media.Imaging;
     using System.Windows.Threading;
     using GalaSoft.MvvmLight.Threading;
     using OnlyM.Core.Extensions;
@@ -66,6 +67,8 @@
         public event EventHandler<MediaEventArgs> MediaChangeEvent;
 
         public event EventHandler<SlideTransitionEventArgs> SlideTransitionEvent;
+
+        public event EventHandler<NewMediaSizeEventArgs> NewMediaSizeEvent;
 
         private bool Image1Populated => _image1.Source != null;
 
@@ -254,6 +257,11 @@
             SlideTransitionEvent?.Invoke(this, e);
         }
 
+        private void OnNewMediaSizeEvent(NewMediaSizeEventArgs e)
+        {
+            NewMediaSizeEvent?.Invoke(this, e);
+        }
+
         private MediaEventArgs CreateMediaEventArgs(Guid id, MediaClassification mediaClassification, MediaChange change)
         {
             if (id == Guid.Empty)
@@ -277,6 +285,15 @@
                 Transition = change,
                 OldSlideIndex = oldIndex,
                 NewSlideIndex = newIndex,
+            };
+        }
+
+        private NewMediaSizeEventArgs CreateNewMediaSizeEventArgs(int width, int height)
+        {
+            return new NewMediaSizeEventArgs
+            {
+                Width = width,
+                Height = height,
             };
         }
 
@@ -373,6 +390,8 @@
             var imageSrc = _optionsService.CacheImages
                 ? ImageCache.GetImage(imageFile)
                 : GraphicsUtils.GetBitmapImageWithCacheOnLoad(imageFile);
+
+            OnNewMediaSizeEvent(CreateNewMediaSizeEventArgs(imageSrc.PixelWidth, imageSrc.PixelHeight));
 
             if (!shouldFadeIn)
             {

--- a/OnlyM/Services/VideoDisplayManager.cs
+++ b/OnlyM/Services/VideoDisplayManager.cs
@@ -48,6 +48,8 @@
         public event EventHandler<MediaNearEndEventArgs> MediaNearEndEvent;
 
         public event EventHandler<SubtitleEventArgs> SubtitleEvent;
+
+        public event EventHandler<NewMediaSizeEventArgs> NewMediaSizeEvent;
         
         public bool ShowSubtitles { get; set; }
 
@@ -146,6 +148,11 @@
             MediaChangeEvent?.Invoke(this, e);
         }
 
+        private void OnNewMediaSizeEvent(NewMediaSizeEventArgs e)
+        {
+            NewMediaSizeEvent?.Invoke(this, e);
+        }
+
         private async void HandleMediaOpened(object sender, System.Windows.RoutedEventArgs e)
         {
             Log.Logger.Information("Opened");
@@ -154,6 +161,7 @@
 
             _mediaElement.Position = _startPosition;
             OnMediaChangeEvent(CreateMediaEventArgs(_mediaItemId, MediaChange.Started));
+            OnNewMediaSizeEvent(CreateNewMediaSizeEventArgs(_mediaElement.NaturalVideoWidth, _mediaElement.NaturalVideoHeight));
 
             await CreateSubtitleProvider(_mediaItemFilePath, _startPosition);
         }
@@ -234,6 +242,15 @@
                     Log.Logger.Warning(e.Message);
                     break;
             }
+        }
+
+        private NewMediaSizeEventArgs CreateNewMediaSizeEventArgs(int width, int height)
+        {
+            return new NewMediaSizeEventArgs
+            {
+                Width = width,
+                Height = height,
+            };
         }
 
         private MediaEventArgs CreateMediaEventArgs(Guid id, MediaChange change)

--- a/OnlyM/ViewModel/SettingsViewModel.cs
+++ b/OnlyM/ViewModel/SettingsViewModel.cs
@@ -872,6 +872,19 @@
             }
         }
 
+        public bool AutoResizeMediaWindow
+        {
+            get => _optionsService.AutoResizeMediaWindow;
+            set
+            {
+                if (_optionsService.AutoResizeMediaWindow != value)
+                {
+                    _optionsService.AutoResizeMediaWindow = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
         private void OnShutDown(ShutDownMessage obj)
         {
             _optionsService.RecentlyUsedMediaFolders = _recentlyUsedMediaFolders.GetFolders().ToList();

--- a/OnlyM/Windows/MediaWindow.xaml.cs
+++ b/OnlyM/Windows/MediaWindow.xaml.cs
@@ -518,7 +518,10 @@
 
         private void HandleNewMediaSizeEvent(object sender, NewMediaSizeEventArgs e)
         {
-            ResizeWindowToMediaSize(e.Width, e.Height);
+            if (_optionsService.MediaWindowed && _optionsService.AutoResizeMediaWindow)
+            {
+                ResizeWindowToMediaSize(e.Width, e.Height);                
+            }
         }
 
         private void ResizeWindowToMediaSize(int width, int height)

--- a/OnlyM/Windows/MediaWindow.xaml.cs
+++ b/OnlyM/Windows/MediaWindow.xaml.cs
@@ -417,6 +417,7 @@
         { 
             _imageDisplayManager.MediaChangeEvent += HandleMediaChangeEvent;
             _imageDisplayManager.SlideTransitionEvent += HandleSlideTransitionEvent;
+            _imageDisplayManager.NewMediaSizeEvent += HandleNewMediaSizeEvent;
         }
 
         private void SubscribeVideoEvents()
@@ -425,6 +426,7 @@
             _videoDisplayManager.MediaPositionChangedEvent += HandleMediaPositionChangedEvent;
             _videoDisplayManager.MediaNearEndEvent += HandleMediaNearEndEvent;
             _videoDisplayManager.SubtitleEvent += HandleMediaFoundationSubtitleEvent;
+            _videoDisplayManager.NewMediaSizeEvent += HandleNewMediaSizeEvent;
         }
 
         private void SubscribeWebEvents()
@@ -471,6 +473,7 @@
         {
             _imageDisplayManager.MediaChangeEvent -= HandleMediaChangeEvent;
             _imageDisplayManager.SlideTransitionEvent -= HandleSlideTransitionEvent;
+            _imageDisplayManager.NewMediaSizeEvent -= HandleNewMediaSizeEvent;
         }
 
         private void UnsubscribeVideoEvents()
@@ -479,6 +482,7 @@
             _videoDisplayManager.MediaPositionChangedEvent -= HandleMediaPositionChangedEvent;
             _videoDisplayManager.MediaNearEndEvent -= HandleMediaNearEndEvent;
             _videoDisplayManager.SubtitleEvent -= HandleMediaFoundationSubtitleEvent;
+            _videoDisplayManager.NewMediaSizeEvent -= HandleNewMediaSizeEvent;
         }
 
         private void UnsubscribeWebEvents()
@@ -510,6 +514,28 @@
         private void HandleShowSubtitlesChangedEvent(object sender, EventArgs e)
         {
             _videoDisplayManager.ShowSubtitles = _optionsService.ShowVideoSubtitles;
+        }
+
+        private void HandleNewMediaSizeEvent(object sender, NewMediaSizeEventArgs e)
+        {
+            ResizeWindowToMediaSize(e.Width, e.Height);
+        }
+
+        private void ResizeWindowToMediaSize(int width, int height)
+        {
+            var wFactor = width / 1920.0;
+            var hFactor = height / 1080.0;
+            if (wFactor > 1 || hFactor > 1)
+            {
+                var transform = Math.Max(wFactor, hFactor);
+                Width = width / transform;
+                Height = height / transform;
+            }
+            else
+            {
+                Width = width;
+                Height = height;
+            }
         }
 
         private bool ShouldConfirmMediaStop(MediaItem mediaItem)

--- a/OnlyM/Windows/SettingsPage.xaml
+++ b/OnlyM/Windows/SettingsPage.xaml
@@ -158,6 +158,11 @@
                 <CheckBox IsChecked="{Binding WindowedAlwaysOnTop, Mode=TwoWay}"
                           Content="{x:Static resx:Resources.MEDIA_WINDOWED_ON_TOP}"
                           Style="{StaticResource SettingsCheckBoxStyle}"/>
+                
+                <CheckBox IsChecked="{Binding AutoResizeMediaWindow, Mode=TwoWay}"
+                          Content="{x:Static resx:Resources.AUTO_RESIZE_MEDIA_WINDOW}"
+                          IsEnabled="{Binding MediaWindowed, Mode=OneWay}"
+                          Style="{StaticResource SettingsCheckBoxStyle}"/>
 
                 <CheckBox IsChecked="{Binding PermanentBackdrop, Mode=TwoWay}"
                           IsEnabled="{Binding JwLibModeNotSet, Mode=OneWay}"


### PR DESCRIPTION
What does this implement/fix? Explain your changes
--------------------------------------------------
Automatically resize media window on new media to media resolution

Does this close any currently open issues?
------------------------------------------
Closes #339 

TODO
-------------------

- [x] Only resize in window mode
- [x] Introduce new user option for auto-resizing
- [ ] Check for problems with high DPI screens
- [ ] Introduce maximum image/video resolution presets in settings. Relates to: https://github.com/AntonyCorbett/OnlyM/blob/b6fbb60073189d968c1ac8d565307a23067efc3b/OnlyM/Services/ImagesCache/ImageCache.cs#L15-L16