### PR TITLE
Add Fixed Windows Size Settings

### DIFF
--- a/OnlyM.Core/Services/Options/IOptionsService.cs
+++ b/OnlyM.Core/Services/Options/IOptionsService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Windows;
 using OnlyM.Core.Models;
 using Serilog.Events;
 
@@ -20,6 +21,8 @@ namespace OnlyM.Core.Services.Options
         event EventHandler WindowedMediaAlwaysOnTopChangedEvent;
 
         event EventHandler<MonitorChangedEventArgs> MediaMonitorChangedEvent;
+
+        event EventHandler MediaWindowSizeChangedEvent;
 
         event EventHandler RenderingMethodChangedEvent;
 
@@ -106,6 +109,8 @@ namespace OnlyM.Core.Services.Options
         string? MediaMonitorId { get; set; }
 
         bool MediaWindowed { get; set; }
+
+        Size MediaWindowSize { get; set; }
 
         bool WindowedAlwaysOnTop { get; set; }
 

--- a/OnlyM.Core/Services/Options/Options.cs
+++ b/OnlyM.Core/Services/Options/Options.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Windows;
 using Newtonsoft.Json;
 using OnlyM.Core.Models;
 using OnlyM.Core.Utils;
@@ -49,6 +50,8 @@ namespace OnlyM.Core.Services.Options
             MagnifierSize = MagnifierSize.Medium;
             MagnifierFrameThickness = DefaultBrowserFrameThickness;
 
+            MediaWindowSize = Size.Empty;
+
             VideoScreenPosition = new ScreenPosition();
             ImageScreenPosition = new ScreenPosition();
             WebScreenPosition = new ScreenPosition();
@@ -68,6 +71,8 @@ namespace OnlyM.Core.Services.Options
         public string? MediaMonitorId { get; set; }
 
         public bool MediaWindowed { get; set; }
+
+        public Size MediaWindowSize { get; set; }
 
         public RenderingMethod RenderingMethod { get; set; }
         

--- a/OnlyM.Core/Services/Options/OptionsService.cs
+++ b/OnlyM.Core/Services/Options/OptionsService.cs
@@ -54,6 +54,8 @@ namespace OnlyM.Core.Services.Options
 
         public event EventHandler<MonitorChangedEventArgs>? MediaMonitorChangedEvent;
 
+        public event EventHandler? MediaWindowSizeChangedEvent;
+
         public event EventHandler? RenderingMethodChangedEvent;
 
         public event EventHandler? PermanentBackdropChangedEvent;
@@ -453,6 +455,20 @@ namespace OnlyM.Core.Services.Options
                     _options.Value.MediaWindowed = value;
 
                     OnMediaMonitorChangedEvent(GetChange(value, MediaMonitorId));
+                }
+            }
+        }
+
+        public Size MediaWindowSize
+        {
+            get => _options.Value.MediaWindowSize;
+            set
+            {
+                if (_options.Value.MediaWindowSize != value)
+                {
+                    _options.Value.MediaWindowSize = value;
+
+                    MediaWindowSizeChangedEvent?.Invoke(this, EventArgs.Empty);
                 }
             }
         }

--- a/OnlyM.Core/Utils/FFmpegUtils.cs
+++ b/OnlyM.Core/Utils/FFmpegUtils.cs
@@ -12,13 +12,13 @@ namespace OnlyM.Core.Utils
         public static Uri FixUnicodeUri(Uri uri)
         {
             return uri;
-            //return new Uri(FixUnicodeString(uri.ToString()));
+            // return new Uri(FixUnicodeString(uri.ToString()));
         }
 
         public static string FixUnicodeString(string s)
         {
             return s;
-            //return Encoding.GetEncoding(0).GetString(Encoding.UTF8.GetBytes(s));
+            // return Encoding.GetEncoding(0).GetString(Encoding.UTF8.GetBytes(s));
         }
     }
 }

--- a/OnlyM/Properties/Resources.Designer.cs
+++ b/OnlyM/Properties/Resources.Designer.cs
@@ -539,6 +539,33 @@ namespace OnlyM.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Fixed size:.
+        /// </summary>
+        public static string MEDIA_WINDOW_FIXED_SIZE {
+            get {
+                return ResourceManager.GetString("MEDIA_WINDOW_FIXED_SIZE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This is the recommended resolution, if you have a good internet connection..
+        /// </summary>
+        public static string MEDIA_WINDOW_RECOMMENDED_SIZE {
+            get {
+                return ResourceManager.GetString("MEDIA_WINDOW_RECOMMENDED_SIZE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Resizable.
+        /// </summary>
+        public static string MEDIA_WINDOW_RESIZABLE {
+            get {
+                return ResourceManager.GetString("MEDIA_WINDOW_RESIZABLE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Windowed.
         /// </summary>
         public static string MEDIA_WINDOWED {

--- a/OnlyM/Properties/Resources.resx
+++ b/OnlyM/Properties/Resources.resx
@@ -572,4 +572,16 @@
     <value>Always on top (windowed)</value>
     <comment>Option in Settings =&gt; Display</comment>
   </data>
+  <data name="MEDIA_WINDOW_FIXED_SIZE" xml:space="preserve">
+    <value>Fixed size:</value>
+    <comment>See Settings =&gt; Display</comment>
+  </data>
+  <data name="MEDIA_WINDOW_RESIZABLE" xml:space="preserve">
+    <value>Resizable</value>
+    <comment>See Settings =&gt; Display</comment>
+  </data>
+  <data name="MEDIA_WINDOW_RECOMMENDED_SIZE" xml:space="preserve">
+    <value>This is the recommended resolution, if you have a good internet connection.</value>
+    <comment>See Settings =&gt; Display</comment>
+  </data>
 </root>

--- a/OnlyM/ViewModel/MediaViewModel.cs
+++ b/OnlyM/ViewModel/MediaViewModel.cs
@@ -20,6 +20,16 @@ namespace OnlyM.ViewModel
         private bool _isWebPage;
         private int _videoRotation;
 
+        private double _height = 500;
+        private double _width = 500;
+
+        private double _minHeight;
+        private double _minWidth;
+        private double _maxHeight;
+        private double _maxWidth;
+
+        private ResizeMode _resizeMode = ResizeMode.CanResize;
+
         public MediaViewModel(IOptionsService optionsService)
         {
             _optionsService = optionsService;
@@ -27,6 +37,9 @@ namespace OnlyM.ViewModel
             _optionsService.RenderingMethodChangedEvent += HandleRenderingMethodChangedEvent;
             _optionsService.MagnifierChangedEvent += HandleMagnifierChangedEvent;
             _optionsService.BrowserChangedEvent += HandleBrowserChangedEvent;
+            _optionsService.MediaWindowSizeChangedEvent += HandleMediaWindowSizeChangedEvent;
+
+            HandleMediaWindowSizeChangedEvent(_optionsService, EventArgs.Empty);
 
             InitCommands();
         }
@@ -74,6 +87,48 @@ namespace OnlyM.ViewModel
                     OnPropertyChanged(nameof(MagnifierRadius));
                 }
             }
+        }
+
+        public ResizeMode ResizeMode
+        {
+            get => _resizeMode;
+            private set => SetProperty(ref _resizeMode, value);
+        }
+
+        public double Height
+        {
+            get => _height;
+            set => SetProperty(ref _height, value);
+        }
+
+        public double Width
+        {
+            get => _width;
+            set => SetProperty(ref _width, value);
+        }
+
+        public double MinHeight
+        {
+            get => _minHeight;
+            set => SetProperty(ref _minHeight, value);
+        }
+
+        public double MinWidth
+        {
+            get => _minWidth;
+            set => SetProperty(ref _minWidth, value);
+        }
+
+        public double MaxHeight
+        {
+            get => _maxHeight;
+            set => SetProperty(ref _maxHeight, value);
+        }
+
+        public double MaxWidth
+        {
+            get => _maxWidth;
+            set => SetProperty(ref _maxWidth, value);
         }
 
         public double BrowserZoomLevelIncrement
@@ -338,6 +393,33 @@ namespace OnlyM.ViewModel
         private void HandleBrowserChangedEvent(object? sender, EventArgs e)
         {
             OnPropertyChanged(nameof(BrowserZoomLevelIncrement));
+        }
+
+        private void HandleMediaWindowSizeChangedEvent(object? sender, EventArgs e)
+        {
+            if (_optionsService.MediaWindowSize.IsEmpty)
+            {
+                MinWidth = 200;
+                MaxWidth = double.PositiveInfinity;
+
+                MinHeight = 160;
+                MaxHeight = double.PositiveInfinity;
+
+                ResizeMode = ResizeMode.CanResize;
+            }
+            else
+            {
+                // Unfortunately just setting ResizeMode doesn't work as expected, so enforce it using min/max 
+                MinWidth = _optionsService.MediaWindowSize.Width;
+                Width = _optionsService.MediaWindowSize.Width;
+                MaxWidth = _optionsService.MediaWindowSize.Width;
+
+                MinHeight = _optionsService.MediaWindowSize.Height;
+                Height = _optionsService.MediaWindowSize.Height;
+                MaxHeight = _optionsService.MediaWindowSize.Height;
+
+                ResizeMode = ResizeMode.CanMinimize;
+            }
         }
     }
 }

--- a/OnlyM/Windows/MediaWindow.xaml
+++ b/OnlyM/Windows/MediaWindow.xaml
@@ -12,12 +12,16 @@
         mc:Ignorable="d"
         Title="OnlyM Media Window" 
         AllowsTransparency="False"
-        Height="500"
-        Width="500"
-        MinHeight="160"
-        MinWidth="200"
+        Height="{Binding Height, Mode=TwoWay}"
+        Width="{Binding Width, Mode=TwoWay}"
+        MaxHeight="{Binding MaxHeight, Mode=OneWay}"
+        MaxWidth="{Binding MaxWidth, Mode=OneWay}"
+        MinHeight="{Binding MinHeight, Mode=OneWay}"
+        MinWidth="{Binding MinWidth, Mode=OneWay}"
         Closing="WindowClosing" 
-        SizeChanged="WindowSizeChanged" MouseDown="Window_MouseDown" >
+        SizeChanged="WindowSizeChanged"
+        MouseDown="Window_MouseDown" 
+        ResizeMode="{Binding ResizeMode, Mode=OneWay}" >
 
     <WindowChrome.WindowChrome>
         <WindowChrome 

--- a/OnlyM/Windows/MediaWindow.xaml.cs
+++ b/OnlyM/Windows/MediaWindow.xaml.cs
@@ -46,8 +46,8 @@ namespace OnlyM.Windows
         private RenderingMethod _currentRenderingMethod;
         
         public MediaWindow(
-            IOptionsService optionsService, 
-            ISnackbarService snackbarService, 
+            IOptionsService optionsService,
+            ISnackbarService snackbarService,
             IDatabaseService databaseService,
             IMonitorsService monitorsService)
         {

--- a/OnlyM/Windows/SettingsPage.xaml
+++ b/OnlyM/Windows/SettingsPage.xaml
@@ -58,6 +58,9 @@
             <Style x:Key="SettingsCheckBoxStyle" TargetType="{x:Type CheckBox}" BasedOn="{StaticResource MaterialDesignCheckBox}">
                 <Setter Property="Margin" Value="0,5,0,5"/>
             </Style>
+            <Style x:Key="SettingsRadioButtonStyle" TargetType="{x:Type RadioButton}" BasedOn="{StaticResource MaterialDesignRadioButton}">
+                <Setter Property="Margin" Value="0,5,0,5"/>
+            </Style>
 
             <Style x:Key="SettingsGroupBoxStyle" TargetType="{x:Type GroupBox}" BasedOn="{StaticResource MaterialDesignGroupBox}">
                 <Setter Property="Width" Value="450" />
@@ -155,6 +158,46 @@
                 <CheckBox IsChecked="{Binding MediaWindowed, Mode=TwoWay}"
                           Content="{x:Static resx:Resources.MEDIA_WINDOWED}"
                           Style="{StaticResource SettingsCheckBoxStyle}"/>
+
+                <StackPanel Orientation="Vertical" Margin="25,0,0,0" IsEnabled="{Binding MediaWindowed, Mode=OneWay}">
+                    <RadioButton GroupName="WindowSize" 
+                                 Content="{x:Static resx:Resources.MEDIA_WINDOW_RESIZABLE}" 
+                                 IsChecked="{Binding MediaWindowResizable, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                                 Style="{StaticResource SettingsRadioButtonStyle}" />
+                    <RadioButton GroupName="WindowSize" 
+                                 IsChecked="{Binding MediaWindowFixed, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                 Style="{StaticResource SettingsRadioButtonStyle}" >
+                        <StackPanel Orientation="Horizontal" IsEnabled="{Binding MediaWindowFixed, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
+                            <TextBlock Text="{x:Static resx:Resources.MEDIA_WINDOW_FIXED_SIZE}" VerticalAlignment="Center" Margin="0,0,10,0" />
+                            <TextBox Text="{Binding MediaWindowWidth, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" MinWidth="50" TextAlignment="Center" ></TextBox>
+                            <TextBlock Text="x" VerticalAlignment="Center" Margin="10,0,10,0" />
+                            <TextBox Text="{Binding MediaWindowHeight, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" MinWidth="50" TextAlignment="Center" ></TextBox>
+                        </StackPanel>
+                    </RadioButton>
+                    <StackPanel Orientation="Horizontal" IsEnabled="{Binding MediaWindowFixed, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Margin="20,0,0,0">
+                        <Button 
+                            Style="{StaticResource MaterialDesignRaisedLightButton}" 
+                            Command="{Binding Set360PSizeCommand}"
+                            Content="360p" />
+                        <Button 
+                            Style="{StaticResource MaterialDesignRaisedLightButton}" 
+                            Margin="10,0,0,0"
+                            Command="{Binding Set480PSizeCommand}"
+                            Content="480p" />
+                        <Button 
+                            Style="{StaticResource MaterialDesignRaisedDarkButton}" 
+                            Margin="10,0,0,0"
+                            Command="{Binding Set720PSizeCommand}"
+                            FontWeight="Bold"
+                            Content="720p"
+                            ToolTip="{x:Static resx:Resources.MEDIA_WINDOW_RECOMMENDED_SIZE}" />
+                        <Button 
+                            Style="{StaticResource MaterialDesignRaisedLightButton}" 
+                            Margin="10,0,0,0"
+                            Command="{Binding Set1080PSizeCommand}"
+                            Content="1080p" />
+                    </StackPanel>
+                </StackPanel>
 
                 <CheckBox IsChecked="{Binding WindowedAlwaysOnTop, Mode=TwoWay}"
                           Content="{x:Static resx:Resources.MEDIA_WINDOWED_ON_TOP}"


### PR DESCRIPTION
What does this implement/fix? Explain your changes
--------------------------------------------------

As discussed in the issue linked below, for Zoom (or other video) meetings, it would be very handy to be able to preconfigure the size of the media window to ensure a consistent media presentation. So this PR adds the possibility to specify a fixed window resolution in the settings. There are also preset buttons for the most common resolutions (360p, 480p, 720p, 1080p). 

![Settings Window](https://raw.githubusercontent.com/drothmaler/shared/main/OnlyM-Window-Settings.png)

Does this close any currently open issues?
------------------------------------------

#339 

Any other comments?
-------------------

Nope...
