### PR TITLE
Add Auto/Manual sort mode with drag-drop reorder and SQLite-backed manual order

### DIFF
--- a/OnlyM.Core/Models/MediaSortMode.cs
+++ b/OnlyM.Core/Models/MediaSortMode.cs
@@ -1,0 +1,7 @@
+﻿namespace OnlyM.Core.Models;
+
+public enum MediaSortMode
+{
+    Auto,
+    Manual,
+}

--- a/OnlyM.Core/Services/Database/DatabaseService.cs
+++ b/OnlyM.Core/Services/Database/DatabaseService.cs
@@ -4,6 +4,7 @@ using System.Data.SQLite;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text;
 using OnlyM.Core.Utils;
 using Serilog;
@@ -13,7 +14,7 @@ namespace OnlyM.Core.Services.Database;
 // ReSharper disable once ClassNeverInstantiated.Global
 public class DatabaseService : IDatabaseService
 {
-    private const int CurrentSchemaVersion = 4;
+    private const int CurrentSchemaVersion = 5;
 
     public DatabaseService()
     {
@@ -145,6 +146,90 @@ public class DatabaseService : IDatabaseService
         return null;
     }
 
+    public IReadOnlyList<string> GetMediaOrderItemKeys(string scopeKey)
+    {
+        var result = new List<string>();
+
+        using var c = CreateConnection();
+        using var cmd = c.CreateCommand();
+        Log.Logger.Verbose("Selecting from mediaOrder table: {ScopeKey}", scopeKey);
+
+        cmd.CommandText = "select itemKey from mediaOrder where scopeKey = @S order by sortIndex";
+        cmd.Parameters.AddWithValue("@S", scopeKey.Trim());
+
+        using var r = cmd.ExecuteReader();
+        while (r.Read())
+        {
+            result.Add((string)r["itemKey"]);
+        }
+
+        return result;
+    }
+
+    public void UpsertMediaOrder(string scopeKey, IReadOnlyList<string> orderedItemKeys)
+    {
+        ArgumentNullException.ThrowIfNull(scopeKey);
+        ArgumentNullException.ThrowIfNull(orderedItemKeys);
+
+        using var c = CreateConnection();
+        using var transaction = c.BeginTransaction();
+
+        var nowUtc = DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture);
+
+        for (var n = 0; n < orderedItemKeys.Count; ++n)
+        {
+            using var cmd = c.CreateCommand();
+
+            cmd.CommandText =
+                "insert into mediaOrder (scopeKey, itemKey, sortIndex, updatedUtc) " +
+                "values (@S, @I, @X, @U) " +
+                "on conflict(scopeKey, itemKey) do update set sortIndex=@X, updatedUtc=@U";
+
+            cmd.Parameters.AddWithValue("@S", scopeKey.Trim());
+            cmd.Parameters.AddWithValue("@I", orderedItemKeys[n].Trim());
+            cmd.Parameters.AddWithValue("@X", n);
+            cmd.Parameters.AddWithValue("@U", nowUtc);
+            cmd.ExecuteNonQuery();
+        }
+
+        transaction.Commit();
+    }
+
+    public void RemoveMissingMediaOrderItems(string scopeKey, IReadOnlyCollection<string> existingItemKeys)
+    {
+        ArgumentNullException.ThrowIfNull(scopeKey);
+        ArgumentNullException.ThrowIfNull(existingItemKeys);
+
+        using var c = CreateConnection();
+        using var cmd = c.CreateCommand();
+
+        if (existingItemKeys.Count == 0)
+        {
+            cmd.CommandText = "delete from mediaOrder where scopeKey = @S";
+            cmd.Parameters.AddWithValue("@S", scopeKey.Trim());
+            cmd.ExecuteNonQuery();
+            return;
+        }
+
+        var parameterNames = existingItemKeys
+            .Select((_, i) => $"@K{i}")
+            .ToArray();
+
+        cmd.CommandText =
+            $"delete from mediaOrder where scopeKey = @S and itemKey not in ({string.Join(",", parameterNames)})";
+
+        cmd.Parameters.AddWithValue("@S", scopeKey.Trim());
+
+        var index = 0;
+        foreach (var itemKey in existingItemKeys)
+        {
+            cmd.Parameters.AddWithValue(parameterNames[index], itemKey.Trim());
+            ++index;
+        }
+
+        cmd.ExecuteNonQuery();
+    }
+
     public BrowserData? GetBrowserData(string url)
     {
         using var c = CreateConnection();
@@ -257,6 +342,7 @@ public class DatabaseService : IDatabaseService
         CreateThumbTable(c);
         CreateBrowserTable(c);
         CreateMediaOptionsTable(c);
+        CreateMediaOrderTable(c);
         SetDatabaseSchemaVersion(c, CurrentSchemaVersion);
     }
 
@@ -317,6 +403,26 @@ public class DatabaseService : IDatabaseService
         sb.AppendLine("[zoom] NUMBER NOT NULL);");
 
         sb.AppendLine("CREATE UNIQUE INDEX[urlIndex] ON[browser]([url]);");
+
+        cmd.CommandText = sb.ToString();
+        cmd.ExecuteNonQuery();
+    }
+
+    private static void CreateMediaOrderTable(SQLiteConnection connection)
+    {
+        using var cmd = connection.CreateCommand();
+        Log.Logger.Verbose("Creating media order table");
+
+        var sb = new StringBuilder();
+        sb.AppendLine("CREATE TABLE[mediaOrder](");
+        sb.AppendLine("[id] INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE,");
+        sb.AppendLine("[scopeKey] TEXT NOT NULL COLLATE NOCASE,");
+        sb.AppendLine("[itemKey] TEXT NOT NULL COLLATE NOCASE,");
+        sb.AppendLine("[sortIndex] INTEGER NOT NULL,");
+        sb.AppendLine("[updatedUtc] TEXT NOT NULL);");
+
+        sb.AppendLine("CREATE UNIQUE INDEX[scopeItemKeyIndex] ON[mediaOrder]([scopeKey], [itemKey]);");
+        sb.AppendLine("CREATE INDEX[scopeSortIndex] ON[mediaOrder]([scopeKey], [sortIndex]);");
 
         cmd.CommandText = sb.ToString();
         cmd.ExecuteNonQuery();

--- a/OnlyM.Core/Services/Database/IDatabaseService.cs
+++ b/OnlyM.Core/Services/Database/IDatabaseService.cs
@@ -1,4 +1,6 @@
-﻿namespace OnlyM.Core.Services.Database;
+﻿using System.Collections.Generic;
+
+namespace OnlyM.Core.Services.Database;
 
 public interface IDatabaseService
 {
@@ -18,4 +20,11 @@ public interface IDatabaseService
     void AddMediaStartOffsetData(string fileName, string startOffsets, int lengthSeconds);
 
     MediaStartOffsetData? GetMediaStartOffsetData(string fileName);
+
+    // manual media ordering...
+    IReadOnlyList<string> GetMediaOrderItemKeys(string scopeKey);
+
+    void UpsertMediaOrder(string scopeKey, IReadOnlyList<string> orderedItemKeys);
+
+    void RemoveMissingMediaOrderItems(string scopeKey, IReadOnlyCollection<string> existingItemKeys);
 }

--- a/OnlyM.Core/Services/Options/IOptionsService.cs
+++ b/OnlyM.Core/Services/Options/IOptionsService.cs
@@ -58,6 +58,8 @@ public interface IOptionsService
 
     event EventHandler DarkModeChangedEvent;
 
+    event EventHandler SortModeChangedEvent;
+
     bool ShouldPurgeBrowserCacheOnStartup { get; set; }
 
     int MetaDataParallelism { get; set; }
@@ -147,6 +149,8 @@ public interface IOptionsService
     char MirrorHotKey { get; set; }
 
     DarkModeOption DarkModeOption { get; set; }
+
+    MediaSortMode SortMode { get; set; }
 
     void SetCommandLineMediaFolder(string folder);
 

--- a/OnlyM.Core/Services/Options/Options.cs
+++ b/OnlyM.Core/Services/Options/Options.cs
@@ -58,6 +58,7 @@ public sealed class Options
 
         AllowMirror = true;
         MirrorZoom = DefaultMirrorZoom;
+        SortMode = MediaSortMode.Auto;
 
         Sanitize();
     }
@@ -151,6 +152,8 @@ public sealed class Options
 
     public DarkModeOption DarkModeOption { get; set; }
 
+    public MediaSortMode SortMode { get; set; }
+
     /// <summary>
     /// Validates the data, correcting automatically as required
     /// </summary>
@@ -216,6 +219,11 @@ public sealed class Options
         if (MirrorHotKey < 'A' || MirrorHotKey > 'Z')
         {
             MirrorHotKey = DefaultMirrorHotKey;
+        }
+
+        if (!Enum.IsDefined(SortMode))
+        {
+            SortMode = MediaSortMode.Auto;
         }
     }
 

--- a/OnlyM.Core/Services/Options/OptionsService.cs
+++ b/OnlyM.Core/Services/Options/OptionsService.cs
@@ -91,6 +91,8 @@ public sealed class OptionsService : IOptionsService
 
     public event EventHandler? DarkModeChangedEvent;
 
+    public event EventHandler? SortModeChangedEvent;
+
     public bool ShouldPurgeBrowserCacheOnStartup
     {
         get => _options.Value.ShouldPurgeBrowserCacheOnStartup;
@@ -343,6 +345,19 @@ public sealed class OptionsService : IOptionsService
             if (_options.Value.MirrorZoom != value)
             {
                 _options.Value.MirrorZoom = Options.GetNormalisedMirrorZoom(value);
+            }
+        }
+    }
+
+    public MediaSortMode SortMode
+    {
+        get => _options.Value.SortMode;
+        set
+        {
+            if (_options.Value.SortMode != value)
+            {
+                _options.Value.SortMode = value;
+                SortModeChangedEvent?.Invoke(this, EventArgs.Empty);
             }
         }
     }

--- a/OnlyM/Models/MediaItem.cs
+++ b/OnlyM/Models/MediaItem.cs
@@ -53,6 +53,7 @@ public class MediaItem : ObservableObject
     private string? _fileNameAsSubTitle;
     private PdfViewStyle _pdfViewStyle = PdfViewStyle.Default;
     private string _chosenPdfPage = "1";
+    private bool _isBeingDragged;
 
     public event EventHandler? PlaybackPositionChangedEvent;
 
@@ -109,6 +110,12 @@ public class MediaItem : ObservableObject
     {
         get => _pauseOnLastFrame;
         set => SetProperty(ref _pauseOnLastFrame, value);
+    }
+
+    public bool IsBeingDragged
+    {
+        get => _isBeingDragged;
+        set => SetProperty(ref _isBeingDragged, value);
     }
 
     public bool AllowFreezeCommand

--- a/OnlyM/PubSubMessages/ExternalDropTargetMessage.cs
+++ b/OnlyM/PubSubMessages/ExternalDropTargetMessage.cs
@@ -1,0 +1,6 @@
+﻿namespace OnlyM.PubSubMessages;
+
+internal sealed class ExternalDropTargetMessage
+{
+    public int TargetIndex { get; init; }
+}

--- a/OnlyM/ViewModel/OperatorViewModel.cs
+++ b/OnlyM/ViewModel/OperatorViewModel.cs
@@ -13,6 +13,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using OnlyM.Core.Models;
+using OnlyM.Core.Services.Database;
 using OnlyM.Core.Services.Media;
 using OnlyM.Core.Services.Options;
 using OnlyM.Core.Utils;
@@ -40,6 +41,7 @@ internal sealed class OperatorViewModel : ObservableObject, IDisposable
     private readonly IMediaProviderService _mediaProviderService;
     private readonly IThumbnailService _thumbnailService;
     private readonly IMediaMetaDataService _metaDataService;
+    private readonly IDatabaseService _databaseService;
     private readonly IOptionsService _optionsService;
     private readonly IPageService _pageService;
     private readonly IMediaStatusChangingService _mediaStatusChangingService;
@@ -59,12 +61,15 @@ internal sealed class OperatorViewModel : ObservableObject, IDisposable
     private bool _startupLoadDone;
     private bool _isLoadingMediaItems;
     private bool _reloadRequestedFromFileChanges;
+    private int? _pendingManualInsertIndex;
+    private long _pendingManualInsertToken;
     private int _thumbnailColWidth = 180;
 
     public OperatorViewModel(
         IMediaProviderService mediaProviderService,
         IThumbnailService thumbnailService,
         IMediaMetaDataService metaDataService,
+        IDatabaseService databaseService,
         IOptionsService optionsService,
         IPageService pageService,
         IFolderWatcherService folderWatcherService,
@@ -93,6 +98,7 @@ internal sealed class OperatorViewModel : ObservableObject, IDisposable
         _thumbnailService.ThumbnailsPurgedEvent += HandleThumbnailsPurgedEvent;
 
         _metaDataService = metaDataService;
+        _databaseService = databaseService;
 
         _optionsService = optionsService;
         _optionsService.MediaFolderChangedEvent += HandleMediaFolderChangedEvent;
@@ -106,6 +112,7 @@ internal sealed class OperatorViewModel : ObservableObject, IDisposable
         _optionsService.OperatingDateChangedEvent += HandleOperatingDateChangedEvent;
         _optionsService.MaxItemCountChangedEvent += HandleMaxItemCountChangedEvent;
         _optionsService.RenderingMethodChangedEvent += HandleRenderingMethodChangedEvent;
+        _optionsService.SortModeChangedEvent += HandleSortModeChangedEvent;
         _optionsService.PermanentBackdropChangedEvent += async (_, _) => await HandlePermanentBackdropChangedEvent();
         _optionsService.IncludeBlankScreenItemChangedEvent += async (_, _) => await HandleIncludeBlankScreenItemChangedEvent();
 
@@ -127,6 +134,7 @@ internal sealed class OperatorViewModel : ObservableObject, IDisposable
         WeakReferenceMessenger.Default.Register<ShutDownMessage>(this, OnShutDown);
         WeakReferenceMessenger.Default.Register<SubtitleFileMessage>(this, OnSubtitleFileActivity);
         WeakReferenceMessenger.Default.Register<ThemeChangedMessage>(this, OnThemeChanged);
+        WeakReferenceMessenger.Default.Register<ExternalDropTargetMessage>(this, OnExternalDropTarget);
     }
 
     public ObservableCollectionEx<MediaItem> MediaItems { get; } = [];
@@ -150,6 +158,38 @@ internal sealed class OperatorViewModel : ObservableObject, IDisposable
     public RelayCommand<Guid?> NextSlideCommand { get; private set; } = null!;
 
     public RelayCommand<Guid?> EnterStartOffsetEditModeCommand { get; private set; } = null!;
+
+    public void MoveMediaItem(MediaItem sourceItem, MediaItem targetItem)
+    {
+        if (sourceItem.IsBlankScreen || targetItem.IsBlankScreen)
+        {
+            return;
+        }
+
+        var sourceIndex = MediaItems.IndexOf(sourceItem);
+        var targetIndex = MediaItems.IndexOf(targetItem);
+
+        if (sourceIndex < 0 || targetIndex < 0 || sourceIndex == targetIndex)
+        {
+            return;
+        }
+
+        var blankIndex = GetBlankScreenIndex();
+        if (blankIndex == 0 && targetIndex == 0)
+        {
+            targetIndex = 1;
+        }
+
+        if (sourceIndex == targetIndex)
+        {
+            return;
+        }
+
+        MediaItems.Move(sourceIndex, targetIndex);
+
+        EnsureBlankScreenIsFirst();
+        PersistManualOrderForCurrentFolder();
+    }
 
     public int ThumbnailColWidth
     {
@@ -194,6 +234,12 @@ internal sealed class OperatorViewModel : ObservableObject, IDisposable
 
     private void HandleOperatingDateChangedEvent(object? sender, EventArgs e) =>
         _pendingLoadMediaItems = true;
+
+    private void HandleSortModeChangedEvent(object? sender, EventArgs e)
+    {
+        _pendingLoadMediaItems = true;
+        _ = Application.Current.Dispatcher.BeginInvoke(new Action(LoadMediaItems));
+    }
 
     private void HandleUnhideAllEvent(object? sender, EventArgs e)
     {
@@ -326,6 +372,18 @@ internal sealed class OperatorViewModel : ObservableObject, IDisposable
         {
             item.RefreshThemeDependentProperties();
         }
+    }
+
+    private void OnExternalDropTarget(object? sender, ExternalDropTargetMessage message)
+    {
+        if (_optionsService.SortMode != MediaSortMode.Manual)
+        {
+            _pendingManualInsertIndex = null;
+            return;
+        }
+
+        _pendingManualInsertIndex = message.TargetIndex;
+        ++_pendingManualInsertToken;
     }
 
     private void LaunchThumbnailQueueConsumer()
@@ -1011,6 +1069,8 @@ internal sealed class OperatorViewModel : ObservableObject, IDisposable
                     MediaItems.Remove(item);
                 }
 
+                var manualInsertTokenSnapshot = _pendingManualInsertToken;
+
                 foreach (var item in itemsToAdd)
                 {
                     MediaItems.Add(item);
@@ -1025,6 +1085,16 @@ internal sealed class OperatorViewModel : ObservableObject, IDisposable
 
                 SortMediaItems();
                 InsertBlankMediaItem();
+
+                if (_optionsService.SortMode == MediaSortMode.Manual &&
+                    _pendingManualInsertIndex.HasValue &&
+                    itemsToAdd.Count > 0 &&
+                    manualInsertTokenSnapshot == _pendingManualInsertToken)
+                {
+                    InsertNewItemsAtPendingManualIndex(itemsToAdd);
+                    PersistManualOrderForCurrentFolder();
+                    _pendingManualInsertIndex = null;
+                }
             }
 
             ChangePlayButtonEnabledStatus();
@@ -1118,6 +1188,54 @@ internal sealed class OperatorViewModel : ObservableObject, IDisposable
         }
     }
 
+    private void InsertNewItemsAtPendingManualIndex(IReadOnlyCollection<MediaItem> newItems)
+    {
+        if (!_pendingManualInsertIndex.HasValue)
+        {
+            return;
+        }
+
+        var insertIndex = _pendingManualInsertIndex.Value;
+
+        var blankIndex = GetBlankScreenIndex();
+        if (blankIndex == 0 && insertIndex <= 0)
+        {
+            insertIndex = 1;
+        }
+
+        if (insertIndex < 0)
+        {
+            insertIndex = 0;
+        }
+
+        if (insertIndex > MediaItems.Count)
+        {
+            insertIndex = MediaItems.Count;
+        }
+
+        var orderedNewItems = newItems
+            .Where(x => !x.IsBlankScreen)
+            .ToList();
+
+        for (var n = 0; n < orderedNewItems.Count; ++n)
+        {
+            var item = orderedNewItems[n];
+            var currentIndex = MediaItems.IndexOf(item);
+            if (currentIndex < 0)
+            {
+                continue;
+            }
+
+            var targetIndex = Math.Min(insertIndex + n, MediaItems.Count - 1);
+            if (currentIndex != targetIndex)
+            {
+                MediaItems.Move(currentIndex, targetIndex);
+            }
+        }
+
+        EnsureBlankScreenIsFirst();
+    }
+
     private MediaItem CreateNewMediaItem(MediaFile file)
     {
         var result = new MediaItem
@@ -1200,11 +1318,86 @@ internal sealed class OperatorViewModel : ObservableObject, IDisposable
 
     private void SortMediaItems()
     {
+        if (_optionsService.SortMode == MediaSortMode.Manual)
+        {
+            SortMediaItemsManual();
+            return;
+        }
+
+        SortMediaItemsAuto();
+    }
+
+    private void SortMediaItemsAuto()
+    {
         var sorted = MediaItems.OrderBy(x => x.SortKey).ToList();
         var blank = sorted.SingleOrDefault(x => x.IsBlankScreen);
         if (blank != null && blank != sorted.First())
         {
             sorted.Remove(blank);
+            sorted.Insert(0, blank);
+        }
+
+        for (var n = 0; n < sorted.Count; ++n)
+        {
+            MediaItems.Move(MediaItems.IndexOf(sorted[n]), n);
+        }
+    }
+
+    private void SortMediaItemsManual()
+    {
+        var mediaFolder = _optionsService.MediaFolder;
+        if (string.IsNullOrWhiteSpace(mediaFolder) || !Directory.Exists(mediaFolder))
+        {
+            SortMediaItemsAuto();
+            return;
+        }
+
+        var scopeKey = mediaFolder.Trim();
+
+        var keyedItems = MediaItems
+            .Where(x => !x.IsBlankScreen && !string.IsNullOrWhiteSpace(x.FilePath))
+            .Select(x => new
+            {
+                Item = x,
+                Key = CreateMediaOrderItemKey(mediaFolder, x.FilePath!),
+            })
+            .ToList();
+
+        var existingKeys = keyedItems
+            .Select(x => x.Key)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        _databaseService.RemoveMissingMediaOrderItems(scopeKey, existingKeys);
+
+        var storedOrderKeys = _databaseService.GetMediaOrderItemKeys(scopeKey);
+
+        var itemByKey = keyedItems
+            .GroupBy(x => x.Key, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First().Item, StringComparer.OrdinalIgnoreCase);
+
+        var sorted = new List<MediaItem>();
+        var usedKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var key in storedOrderKeys)
+        {
+            if (itemByKey.TryGetValue(key, out var item) && usedKeys.Add(key))
+            {
+                sorted.Add(item);
+            }
+        }
+
+        var newItems = keyedItems
+            .Where(x => !usedKeys.Contains(x.Key))
+            .Select(x => x.Item)
+            .OrderBy(x => x.SortKey)
+            .ToList();
+
+        sorted.AddRange(newItems);
+
+        var blank = MediaItems.SingleOrDefault(x => x.IsBlankScreen);
+        if (blank != null)
+        {
             sorted.Insert(0, blank);
         }
 
@@ -1220,6 +1413,56 @@ internal sealed class OperatorViewModel : ObservableObject, IDisposable
         {
             _metaDataProducer.Add(item);
         }
+    }
+
+    private static string CreateMediaOrderItemKey(string mediaFolder, string fullPath)
+    {
+        var relativePath = Path.GetRelativePath(mediaFolder, fullPath);
+        return relativePath.Replace('\\', '/').Trim();
+    }
+
+    private int GetBlankScreenIndex()
+    {
+        for (var i = 0; i < MediaItems.Count; ++i)
+        {
+            if (MediaItems[i].IsBlankScreen)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private void EnsureBlankScreenIsFirst()
+    {
+        var blankIndex = GetBlankScreenIndex();
+        if (blankIndex > 0)
+        {
+            MediaItems.Move(blankIndex, 0);
+        }
+    }
+
+    private void PersistManualOrderForCurrentFolder()
+    {
+        var mediaFolder = _optionsService.MediaFolder;
+        if (string.IsNullOrWhiteSpace(mediaFolder) || !Directory.Exists(mediaFolder))
+        {
+            return;
+        }
+
+        _optionsService.SortMode = MediaSortMode.Manual;
+        _optionsService.Save();
+
+        var scopeKey = mediaFolder.Trim();
+
+        var orderedItemKeys = MediaItems
+            .Where(x => !x.IsBlankScreen && !string.IsNullOrWhiteSpace(x.FilePath))
+            .Select(x => CreateMediaOrderItemKey(mediaFolder, x.FilePath!))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        _databaseService.UpsertMediaOrder(scopeKey, orderedItemKeys);
     }
 
     private async Task AutoRotateImageIfRequiredAsync(MediaItem item)

--- a/OnlyM/ViewModel/SettingsViewModel.cs
+++ b/OnlyM/ViewModel/SettingsViewModel.cs
@@ -491,6 +491,34 @@ internal sealed class SettingsViewModel : ObservableObject
         }
     }
 
+    public bool IsAutoSortMode
+    {
+        get => _optionsService.SortMode == MediaSortMode.Auto;
+        set
+        {
+            if (value && _optionsService.SortMode != MediaSortMode.Auto)
+            {
+                _optionsService.SortMode = MediaSortMode.Auto;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(IsManualSortMode));
+            }
+        }
+    }
+
+    public bool IsManualSortMode
+    {
+        get => _optionsService.SortMode == MediaSortMode.Manual;
+        set
+        {
+            if (value && _optionsService.SortMode != MediaSortMode.Manual)
+            {
+                _optionsService.SortMode = MediaSortMode.Manual;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(IsAutoSortMode));
+            }
+        }
+    }
+
     public bool UseInternalMediaTitles
     {
         get => _optionsService.UseInternalMediaTitles;

--- a/OnlyM/Windows/OperatorPage.xaml
+++ b/OnlyM/Windows/OperatorPage.xaml
@@ -1,22 +1,23 @@
 ﻿<UserControl
-    x:Class="OnlyM.Windows.OperatorPage"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:controls="clr-namespace:OnlyM.Controls"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:models="clr-namespace:OnlyM.Models"
-    xmlns:resx="clr-namespace:OnlyM.Properties"
-    x:Name="OnlyMOperatorPage"
-    d:DesignHeight="450"
-    d:DesignWidth="600"
-    AllowDrop="True"
-    Background="{DynamicResource MaterialDesignPaper}"
-    DataContext="{Binding Operator, Mode=OneWay, Source={StaticResource Locator}}"
-    FontFamily="{DynamicResource MaterialDesignFont}"
-    Loaded="OnLoaded"
-    SizeChanged="OnlyMOperatorPage_SizeChanged"
+x:Class="OnlyM.Windows.OperatorPage"
+xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+xmlns:controls="clr-namespace:OnlyM.Controls"
+xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+xmlns:models="clr-namespace:OnlyM.Models"
+xmlns:resx="clr-namespace:OnlyM.Properties"
+x:Name="OnlyMOperatorPage"
+d:DesignHeight="450"
+d:DesignWidth="600"
+AllowDrop="True"
+Background="{DynamicResource MaterialDesignPaper}"
+DataContext="{Binding Operator, Mode=OneWay, Source={StaticResource Locator}}"
+FontFamily="{DynamicResource MaterialDesignFont}"
+Loaded="OnLoaded"
+Unloaded="OnUnloaded"
+SizeChanged="OnlyMOperatorPage_SizeChanged"
     TextElement.FontSize="18"
     TextElement.FontWeight="Regular"
     TextElement.Foreground="{DynamicResource MaterialDesignBody}"
@@ -49,6 +50,21 @@
                     materialDesign:ElevationAssist.Elevation="Dp1"
                     materialDesign:ShadowAssist.ShadowEdges="All"
                     Visibility="{Binding Path=IsVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+
+                    <materialDesign:Card.Style>
+                        <Style TargetType="materialDesign:Card">
+                            <Setter Property="Opacity" Value="1" />
+                            <Setter Property="BorderBrush" Value="Transparent" />
+                            <Setter Property="BorderThickness" Value="0" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsBeingDragged}" Value="True">
+                                    <Setter Property="Opacity" Value="0.45" />
+                                    <Setter Property="BorderBrush" Value="{DynamicResource ValidationErrorBrush}" />
+                                    <Setter Property="BorderThickness" Value="4" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </materialDesign:Card.Style>
 
                     <materialDesign:DrawerHost IsLeftDrawerOpen="{Binding IsCommandPanelOpen, Mode=TwoWay}">
 
@@ -479,9 +495,16 @@
     </UserControl.Triggers>
 
     <ListBox
+        x:Name="OperatorMediaList"
+        AllowDrop="True"
         Background="Transparent"
         BorderThickness="0"
+        DragOver="OperatorMediaList_DragOver"
+        Drop="OperatorMediaList_Drop"
+        GiveFeedback="OperatorMediaList_GiveFeedback"
         ItemsSource="{Binding MediaItems}"
+        PreviewMouseLeftButtonDown="OperatorMediaList_PreviewMouseLeftButtonDown"
+        PreviewMouseMove="OperatorMediaList_PreviewMouseMove"
         VirtualizingPanel.VirtualizationMode="Recycling">
         <ListBox.ItemContainerStyle>
             <Style TargetType="{x:Type ListBoxItem}">

--- a/OnlyM/Windows/OperatorPage.xaml.cs
+++ b/OnlyM/Windows/OperatorPage.xaml.cs
@@ -1,8 +1,13 @@
 ﻿using System;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Threading;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.Mvvm.Messaging;
+using OnlyM.Models;
 using OnlyM.PubSubMessages;
 using OnlyM.Services.DragAndDrop;
 using OnlyM.ViewModel;
@@ -14,6 +19,12 @@ namespace OnlyM.Windows;
 /// </summary>
 public partial class OperatorPage
 {
+    private Point _dragStartPoint;
+    private MediaItem? _draggedItem;
+    private Popup? _dragPopup;
+    private TextBlock? _dragPopupText;
+    private DispatcherTimer? _dragPopupSafetyTimer;
+
     public OperatorPage()
     {
         InitializeComponent();
@@ -26,6 +37,19 @@ public partial class OperatorPage
     {
         var vm = (OperatorViewModel?)DataContext;
         vm?.TriggerStartupLoad();
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        HideDragPopup();
+
+        if (_draggedItem != null)
+        {
+            _draggedItem.IsBeingDragged = false;
+            _draggedItem = null;
+        }
+
+        Mouse.OverrideCursor = null;
     }
 
     private void MirrorCheckBoxChecked(object? sender, RoutedEventArgs e) =>
@@ -58,5 +82,185 @@ public partial class OperatorPage
             >= 400 => 100,
             _ => 46
         };
+    }
+
+    private void OperatorMediaList_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e) =>
+        _dragStartPoint = e.GetPosition(null);
+
+    private void OperatorMediaList_PreviewMouseMove(object sender, MouseEventArgs e)
+    {
+        if (e.LeftButton != MouseButtonState.Pressed)
+        {
+            return;
+        }
+
+        var currentPos = e.GetPosition(null);
+
+        if (Math.Abs(currentPos.X - _dragStartPoint.X) < SystemParameters.MinimumHorizontalDragDistance &&
+            Math.Abs(currentPos.Y - _dragStartPoint.Y) < SystemParameters.MinimumVerticalDragDistance)
+        {
+            return;
+        }
+
+        _draggedItem = GetMediaItemFromOriginalSource(e.OriginalSource as DependencyObject);
+
+        if (_draggedItem == null || _draggedItem.IsBlankScreen)
+        {
+            return;
+        }
+
+        try
+        {
+            _draggedItem.IsBeingDragged = true;
+            ShowDragPopup(_draggedItem);
+            Dispatcher.Invoke(() => { }, DispatcherPriority.Render);
+            Mouse.OverrideCursor = Cursors.SizeAll;
+            DragDrop.DoDragDrop((DependencyObject)sender, _draggedItem, DragDropEffects.Move);
+        }
+        finally
+        {
+            Mouse.OverrideCursor = null;
+            HideDragPopup();
+
+            if (_draggedItem != null)
+            {
+                _draggedItem.IsBeingDragged = false;
+            }
+        }
+    }
+
+    private void OperatorMediaList_DragOver(object sender, DragEventArgs e)
+    {
+        if (e.Data.GetDataPresent(typeof(MediaItem)))
+        {
+            e.Effects = DragDropEffects.Move;
+            e.Handled = true;
+            return;
+        }
+
+        e.Effects = DragDropEffects.None;
+    }
+
+    private void OperatorMediaList_GiveFeedback(object sender, GiveFeedbackEventArgs e)
+    {
+        UpdateDragPopupPosition();
+        e.UseDefaultCursors = false;
+        Mouse.SetCursor(Cursors.SizeAll);
+        e.Handled = true;
+    }
+
+    private void OperatorMediaList_Drop(object sender, DragEventArgs e)
+    {
+        var vm = DataContext as OperatorViewModel;
+        if (vm == null)
+        {
+            return;
+        }
+
+        var targetItem = GetMediaItemFromOriginalSource(e.OriginalSource as DependencyObject);
+
+        if (e.Data.GetDataPresent(typeof(MediaItem)))
+        {
+            var sourceItem = e.Data.GetData(typeof(MediaItem)) as MediaItem;
+
+            if (sourceItem == null || targetItem == null || sourceItem == targetItem || sourceItem.IsBlankScreen || targetItem.IsBlankScreen)
+            {
+                return;
+            }
+
+            vm.MoveMediaItem(sourceItem, targetItem);
+            return;
+        }
+
+        var targetIndex = targetItem == null
+            ? vm.MediaItems.Count
+            : vm.MediaItems.IndexOf(targetItem);
+
+        if (targetIndex < 0)
+        {
+            targetIndex = vm.MediaItems.Count;
+        }
+
+        WeakReferenceMessenger.Default.Send(new ExternalDropTargetMessage { TargetIndex = targetIndex });
+    }
+
+    private static MediaItem? GetMediaItemFromOriginalSource(DependencyObject? source)
+    {
+        while (source != null)
+        {
+            if (source is FrameworkElement { DataContext: MediaItem mediaItem })
+            {
+                return mediaItem;
+            }
+
+            source = VisualTreeHelper.GetParent(source);
+        }
+
+        return null;
+    }
+
+    private void ShowDragPopup(MediaItem item)
+    {
+        HideDragPopup();
+
+        _dragPopupText = new TextBlock
+        {
+            Text = string.IsNullOrWhiteSpace(item.Title) ? "Moving item" : $"Moving: {item.Title}",
+            Foreground = Brushes.White,
+            Background = Brushes.Black,
+            Opacity = 0.88,
+            Padding = new Thickness(10, 6, 10, 6),
+            FontWeight = FontWeights.SemiBold,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+            MaxWidth = 320,
+        };
+
+        _dragPopup = new Popup
+        {
+            AllowsTransparency = true,
+            Placement = PlacementMode.Absolute,
+            StaysOpen = true,
+            IsHitTestVisible = false,
+            Child = _dragPopupText,
+            IsOpen = true,
+        };
+
+        _dragPopupSafetyTimer?.Stop();
+        _dragPopupSafetyTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(2) };
+        _dragPopupSafetyTimer.Tick += (_, _) =>
+        {
+            _dragPopupSafetyTimer?.Stop();
+            _dragPopupSafetyTimer = null;
+            HideDragPopup();
+        };
+        _dragPopupSafetyTimer.Start();
+
+        UpdateDragPopupPosition();
+    }
+
+    private void UpdateDragPopupPosition()
+    {
+        if (_dragPopup == null || !_dragPopup.IsOpen)
+        {
+            return;
+        }
+
+        var p = System.Windows.Forms.Cursor.Position;
+        _dragPopup.HorizontalOffset = p.X + 16;
+        _dragPopup.VerticalOffset = p.Y + 20;
+    }
+
+    private void HideDragPopup()
+    {
+        _dragPopupSafetyTimer?.Stop();
+        _dragPopupSafetyTimer = null;
+
+        if (_dragPopup != null)
+        {
+            _dragPopup.IsOpen = false;
+            _dragPopup.Child = null;
+            _dragPopup = null;
+            _dragPopupText = null;
+        }
     }
 }

--- a/OnlyM/Windows/SettingsPage.xaml
+++ b/OnlyM/Windows/SettingsPage.xaml
@@ -335,6 +335,21 @@
                     IsChecked="{Binding ShowCommandPanel, Mode=TwoWay}"
                     Style="{StaticResource SettingsCheckBoxStyle}" />
 
+                <StackPanel Margin="0,4,0,2" Orientation="Horizontal">
+                    <TextBlock Margin="0,0,14,0" VerticalAlignment="Center" Text="Sort mode:" />
+                    <RadioButton
+                        Content="Auto"
+                        GroupName="MediaSortMode"
+                        IsChecked="{Binding IsAutoSortMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                        Style="{StaticResource SettingsRadioButtonStyle}" />
+                    <RadioButton
+                        Margin="12,5,0,5"
+                        Content="Manual"
+                        GroupName="MediaSortMode"
+                        IsChecked="{Binding IsManualSortMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                        Style="{StaticResource SettingsRadioButtonStyle}" />
+                </StackPanel>
+
                 <TextBox
                     materialDesign:HintAssist.Hint="{x:Static resx:Resources.MAX_ITEMS}"
                     Style="{StaticResource SettingsTextBoxStyle}"


### PR DESCRIPTION
Summary
Implements media list sorting with two modes:
•	Auto: existing alphabetical behavior
•	Manual: user-defined ordering persisted in SQLite

User Functional changes:
1) Normal Auto mode is unaffected. However, you can drag and drop which will automatically switch to manual mode.
2) Settings has a new switch Auto or Manual. 
3) In manual mode you can drag and drop external files to a certain location in the list, and they will be placed at that index location.
4) If you delete files from the media-folder, in manual mode (the user won't notice, but they are dropped from the SQLLite DB.... any files put in randomly... see 6). You can even delete all the files in the media folder, in whatever manual order they were in. Then replace them back... in this case they would come back in Alpha.
5) if the user switches the settings to manual. (no immediate change will be seen). However, if he was in manual-mode. and he had reordered the list, and he then switches to 'Auto'. It will then of course reorder the list to 'Alpha'. If he switches back again  to 'Manual'. The DB is not deleted in that case, it will attempt to see what files are not stale in the db, so it may return to the order he had in 'Manual' before. But no error will occur. 
Edit: 6) .... A single new file just dropped directly in the Media-Folder in Explorer in Manual-Mode is just appended at the bottom. (I think I'm happy with this...., but it was actually by accident, haha, just found in testing)

What changed
•	Added MediaSortMode (Auto, Manual) in options/settings.
•	Added SortMode to options service and settings UI radio buttons.
•	Added SQLite mediaOrder table and DB service methods:
•	read ordered keys
•	upsert ordered set
•	remove stale missing-file rows
•	Added in-list drag/drop reorder.
•	Reorder now forces sort mode to Manual and persists order.
•	Added external-drop target capture for future/manual-mode insertion-at-drop-position flow.
•	Enforced blank-screen invariant:
•	blank-screen remains index 0
•	cannot reorder items before blank-screen when visible
•	Added drag visual feedback (cursor + moving overlay) and hardened popup cleanup.
Behavior notes
•	In Auto mode, list remains alphabetical and does not continuously rewrite manual order.
•	In Manual mode, SQLite order is used; new items append as designed unless inserted by drop logic.
•	Stale DB order entries are cleaned when files no longer exist.
Testing
•	Build successful.
•	OnlyM.Core.Tests: 114/114 passing.
•	OnlyM.Tests: 20/20 passing.
•	Manual verification:
•	drag/drop reorder
•	mode switching
•	blank-screen pinned behavior
•	popup cleanup on unload/navigation 
Risk / migration note
•	DB schema version changed (to add mediaOrder table). Existing DB content reset behavior should be acknowledged in release notes.

More testing: I have done some brute force testing of the drag and drop. And noticed one time that the 'Move' message stayed on the screen, so I made sure that was hardened, and cleaned up. Still more testing is in order. I have switched back and forth between Auto and Manual. I have tested with the 'Blank Screen' on index 0, and made sure that is unaffected, and that you can't drop beyond that point. 
Edit: Also tested with the 'Hide' function employed. Not sure it could be any better than expected here. I see it as fine.

Thanks Robert Koernke
